### PR TITLE
Fix case where var_pooled contains zeros

### DIFF
--- a/neuroCombat/neuroCombat.py
+++ b/neuroCombat/neuroCombat.py
@@ -236,7 +236,7 @@ def standardize_across_features(X, design, info_dict):
     else:
         var_pooled = np.dot(((X - np.dot(design, B_hat).T)**2), np.ones((n_sample, 1)) / float(n_sample))
 
-    var_pooled[var_pooled==0] = np.median(var_pooled!=0)
+    var_pooled[var_pooled==0] = np.median(var_pooled[var_pooled!=0])
     
     mod_mean = 0
     if design is not None:


### PR DESCRIPTION
Hi @Jfortin1 

Thanks for providing this python package, this has been incredibly useful for some research I'm doing currently.

When adjusting the values of the `var_pooled` array that are zero, I think it was meant to take the median of the nonzero values of the array, not the median of the intermediate binary array (which would either be 0 or 1).

Let me know if this change is correct, I haven't studied the code extremely in-depth.

Thanks again,
Tom